### PR TITLE
Add LLM metadata builder and prompt hash utilities

### DIFF
--- a/backend/app/llm/base.py
+++ b/backend/app/llm/base.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar
+
+from app.config.llm_config import LLMConfig
+from app.services.llm_metadata_builder import build_llm_metadata
 
 
 class LLMClientError(Exception):
@@ -11,7 +16,29 @@ class LLMTimeoutError(LLMClientError):
     """Raised when an LLM request times out."""
 
 
+GenerateCallable = TypeVar("GenerateCallable", bound=Callable[..., Awaitable[str]])
+
+
 class BaseLLMClient(ABC):
+    last_meta_data: dict[str, Any] | None = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        original_generate = cls.__dict__.get("generate")
+        if original_generate is None:
+            return
+        if getattr(original_generate, "_metadata_wrapped", False):
+            return
+
+        @wraps(original_generate)
+        async def _wrapped_generate(self, system_prompt: str, user_prompt: str, **kwargs):
+            config = getattr(self, "config", None) or LLMConfig()
+            extra = kwargs.get("meta_data")
+            self.last_meta_data = build_llm_metadata(config, system_prompt, extra=extra)
+            return await original_generate(self, system_prompt, user_prompt, **kwargs)
+
+        _wrapped_generate._metadata_wrapped = True  # type: ignore[attr-defined]
+        cls.generate = _wrapped_generate  # type: ignore[assignment]
     @abstractmethod
     async def generate(
         self,

--- a/backend/app/services/llm_metadata_builder.py
+++ b/backend/app/services/llm_metadata_builder.py
@@ -1,0 +1,41 @@
+"""Builder for LLM session metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.config.llm_config import LLMConfig
+from app.utils.prompt_hash import generate_prompt_hash
+
+
+def build_llm_metadata(
+    config: LLMConfig,
+    system_prompt: str,
+    extra: dict | None = None,
+) -> dict[str, Any]:
+    """Build metadata for LLM session tracking."""
+
+    config_max_turns = getattr(config, "max_turns", None)
+    metadata: dict[str, Any] = {
+        "provider": config.provider,
+        "model_name": config.model,
+        "temperature": config.temperature,
+        "system_prompt_hash": generate_prompt_hash(system_prompt),
+        "config_max_turns": config_max_turns,
+    }
+
+    if extra:
+        metadata.update(extra)
+
+    if metadata.get("config_max_turns") is None and extra and "config_max_turns" in extra:
+        metadata["config_max_turns"] = extra["config_max_turns"]
+
+    metadata["provider"] = config.provider
+    metadata["model_name"] = config.model
+    metadata["temperature"] = config.temperature
+    metadata["system_prompt_hash"] = generate_prompt_hash(system_prompt)
+
+    if "config_max_turns" not in metadata:
+        metadata["config_max_turns"] = config_max_turns
+
+    return metadata

--- a/backend/app/utils/prompt_hash.py
+++ b/backend/app/utils/prompt_hash.py
@@ -1,0 +1,30 @@
+"""Utilities for normalizing system prompts and generating stable hashes."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+_SPACE_RE = re.compile(r"[ \t\f\v]+")
+
+
+def normalize_prompt(prompt: str) -> str:
+    """Normalize a prompt for stable hashing.
+
+    - Strip leading/trailing whitespace
+    - Normalize newlines to LF
+    - Collapse consecutive spaces/tabs into a single space
+    """
+
+    prompt_value = "" if prompt is None else str(prompt)
+    normalized = prompt_value.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = normalized.strip()
+    normalized = _SPACE_RE.sub(" ", normalized)
+    return normalized
+
+
+def generate_prompt_hash(prompt: str) -> str:
+    """Generate a SHA256 hex digest for a normalized prompt."""
+
+    normalized = normalize_prompt(prompt)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()

--- a/backend/tests/test_prompt_hash.py
+++ b/backend/tests/test_prompt_hash.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+
+def _load_module(module_name: str, relative_path: str):
+    module_path = Path(__file__).resolve().parents[1] / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module {module_name} from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+prompt_hash = _load_module("prompt_hash", "app/utils/prompt_hash.py")
+metadata_builder = _load_module("llm_metadata_builder", "app/services/llm_metadata_builder.py")
+llm_config = _load_module("llm_config", "app/config/llm_config.py")
+llm_mock = _load_module("llm_mock", "app/llm/mock_client.py")
+
+
+def test_hash_matches_newline_variants():
+    prompt_lf = "Hello\nWorld"
+    prompt_crlf = "Hello\r\nWorld"
+    assert prompt_hash.generate_prompt_hash(prompt_lf) == prompt_hash.generate_prompt_hash(prompt_crlf)
+
+
+def test_hash_matches_space_variants():
+    prompt_multi = "Hello   World"
+    prompt_single = "Hello World"
+    assert prompt_hash.generate_prompt_hash(prompt_multi) == prompt_hash.generate_prompt_hash(prompt_single)
+
+
+def test_hash_differs_for_distinct_prompts():
+    assert prompt_hash.generate_prompt_hash("Hello World") != prompt_hash.generate_prompt_hash("Hello Mars")
+
+
+def test_hash_none_safe():
+    assert prompt_hash.generate_prompt_hash(None) == prompt_hash.generate_prompt_hash("")
+
+
+def test_build_llm_metadata_contains_hash():
+    config = llm_config.LLMConfig(provider="mock", model="mock-v1", temperature=0.5, max_tokens=10)
+    metadata = metadata_builder.build_llm_metadata(config, "System\nPrompt", extra={"config_max_turns": 5})
+    assert metadata["provider"] == "mock"
+    assert metadata["model_name"] == "mock-v1"
+    assert metadata["temperature"] == 0.5
+    assert metadata["config_max_turns"] == 5
+    assert metadata["system_prompt_hash"] == prompt_hash.generate_prompt_hash("System\nPrompt")
+
+
+def test_mock_client_builds_metadata():
+    client = llm_mock.MockLLMClient(llm_config.LLMConfig())
+    asyncio.run(client.generate("System Prompt", "Hello"))
+    assert isinstance(client.last_meta_data, dict)
+    assert client.last_meta_data["system_prompt_hash"] == prompt_hash.generate_prompt_hash("System Prompt")


### PR DESCRIPTION
Introduce a builder for LLM session metadata and utilities for generating stable hashes of system prompts, along with corresponding tests to ensure functionality.