### PR TITLE
Add Phase1 chat turn API with error handling and logging

### DIFF
--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -29,4 +29,7 @@ class Session(SQLModel, table=True):
         default_factory=dict,
         sa_column=sa.Column(sa.JSON, nullable=False),
     )
-    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )

--- a/backend/app/repositories/session_repository.py
+++ b/backend/app/repositories/session_repository.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any
+from uuid import UUID
 
 from sqlmodel import Session
 
@@ -21,8 +22,26 @@ def create_phase1_session(
         session_date=session_date,
         log_json=log_json,
         meta_data=meta_data,
-        created_at=datetime.utcnow(),
+    created_at=datetime.now(timezone.utc),
     )
     session.add(new_session)
     session.flush()
     return new_session
+
+
+def get_session_by_id(session: Session, session_id: UUID) -> SessionModel | None:
+    return session.get(SessionModel, session_id)
+
+
+def update_session_log(
+    session: Session,
+    session_id: UUID,
+    log_json: list[dict[str, Any]],
+) -> SessionModel | None:
+    existing = session.get(SessionModel, session_id)
+    if existing is None:
+        return None
+    existing.log_json = log_json
+    session.add(existing)
+    session.flush()
+    return existing

--- a/backend/app/schemas/phase1_chat_schema.py
+++ b/backend/app/schemas/phase1_chat_schema.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class Phase1ChatTurnRequest(BaseModel):
+    message: str = Field(..., min_length=1)
+
+
+class Phase1ChatTurnResponse(BaseModel):
+    session_id: UUID
+    assistant_message: str
+    turn_index: int

--- a/backend/app/services/phase1_chat_service.py
+++ b/backend/app/services/phase1_chat_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import Session
+
+from app.config.llm_config import LLMConfig
+from app.llm.factory import get_llm_client
+from app.prompts.prompt_loader import load_prompt
+from app.repositories import session_repository
+
+
+class Phase1ChatError(RuntimeError):
+    """Base error for Phase1 chat turn operations."""
+
+
+class InvalidMessageError(Phase1ChatError):
+    """Raised when the user message is invalid."""
+
+
+class SessionNotFoundError(Phase1ChatError):
+    """Raised when a session is not found."""
+
+
+class PhaseMismatchError(Phase1ChatError):
+    """Raised when a session phase does not match Phase1."""
+
+
+class LLMGenerateError(Phase1ChatError):
+    """Raised when the LLM fails to generate a response."""
+
+
+class SessionUpdateError(Phase1ChatError):
+    """Raised when a session update fails."""
+
+
+def _normalize_log_json(log_json: Any) -> list[dict[str, Any]]:
+    if isinstance(log_json, list):
+        return list(log_json)
+    if isinstance(log_json, dict):
+        return [log_json]
+    return []
+
+
+async def append_phase1_turn(
+    session: Session,
+    session_id: UUID,
+    message: str,
+) -> tuple[str, int]:
+    cleaned = message.strip() if message is not None else ""
+    if not cleaned:
+        raise InvalidMessageError("message must not be empty")
+
+    existing = session_repository.get_session_by_id(session, session_id)
+    if existing is None:
+        raise SessionNotFoundError("session not found")
+    if existing.phase != 1:
+        raise PhaseMismatchError("phase mismatch")
+
+    system_prompt = load_prompt("phase1")
+    llm_client = get_llm_client(LLMConfig())
+
+    try:
+        assistant_response = await llm_client.generate(system_prompt, cleaned)
+    except Exception as exc:  # noqa: BLE001
+        raise LLMGenerateError("LLM generation failed") from exc
+
+    updated_log = _normalize_log_json(existing.log_json)
+    updated_log.append({"role": "user", "content": cleaned})
+    updated_log.append({"role": "assistant", "content": assistant_response})
+
+    try:
+        updated = session_repository.update_session_log(
+            session=session,
+            session_id=existing.id,
+            log_json=updated_log,
+        )
+        if updated is None:
+            raise SessionNotFoundError("session not found")
+        session.commit()
+        session.refresh(updated)
+    except SQLAlchemyError as exc:
+        session.rollback()
+        raise SessionUpdateError("Failed to update session log") from exc
+
+    turn_index = len(updated_log) - 1
+    return assistant_response, turn_index

--- a/backend/tests/test_phase1_chat_api.py
+++ b/backend/tests/test_phase1_chat_api.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from datetime import date
+from uuid import UUID, uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session as SqlSession, create_engine
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+from app.api.phase1_router import router as phase1_router
+from app.core.db import get_session
+from app.models.session import Session as SessionModel
+from app.models.user import User
+from app.services import phase1_service
+
+
+def _build_test_app():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    app = FastAPI()
+    app.include_router(phase1_router)
+
+    def _override_get_session():
+        with SqlSession(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    return app, engine
+
+
+def _create_user(engine) -> int:
+    with SqlSession(engine) as session:
+        user = User(name="Test User")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return int(user.id)
+
+
+def _create_phase1_session(engine, user_id: int) -> UUID:
+    with SqlSession(engine) as session:
+        created = phase1_service.start_phase1_session(session, user_id)
+        return created.id
+
+
+def test_append_phase1_turn_success():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+    session_id = _create_phase1_session(engine, user_id)
+    client = TestClient(app)
+
+    with SqlSession(engine) as session:
+        before = session.get(SessionModel, session_id)
+        assert before is not None
+        before_meta = dict(before.meta_data)
+
+    response = client.post(
+        f"/api/v1/phase1/session/{session_id}/turn",
+        json={"message": "今日はチームの目標を整理しました"},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["session_id"] == str(session_id)
+    assert "[MOCK RESPONSE]" in data["assistant_message"]
+    assert isinstance(data["turn_index"], int)
+
+    with SqlSession(engine) as session:
+        updated = session.get(SessionModel, session_id)
+        assert updated is not None
+        assert isinstance(updated.log_json, list)
+        assert updated.log_json[-2]["role"] == "user"
+        assert updated.log_json[-1]["role"] == "assistant"
+        assert updated.meta_data == before_meta
+
+
+def test_append_phase1_turn_session_not_found():
+    app, _engine = _build_test_app()
+    client = TestClient(app)
+
+    response = client.post(
+        f"/api/v1/phase1/session/{uuid4()}/turn",
+        json={"message": "こんにちは"},
+    )
+    assert response.status_code == 404
+
+
+def test_append_phase1_turn_phase_mismatch():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+
+    with SqlSession(engine) as session:
+        wrong_phase = SessionModel(
+            id=uuid4(),
+            user_id=user_id,
+            session_date=date.today(),
+            phase=2,
+            log_json=[{"role": "system", "content": "system"}],
+            meta_data={},
+        )
+        session.add(wrong_phase)
+        session.commit()
+        session.refresh(wrong_phase)
+        session_id = wrong_phase.id
+
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/phase1/session/{session_id}/turn",
+        json={"message": "phase error"},
+    )
+    assert response.status_code == 400
+
+
+def test_append_phase1_turn_log_order():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+    session_id = _create_phase1_session(engine, user_id)
+    client = TestClient(app)
+
+    response = client.post(
+        f"/api/v1/phase1/session/{session_id}/turn",
+        json={"message": "ログ順序確認"},
+    )
+    assert response.status_code == 200
+
+    with SqlSession(engine) as session:
+        updated = session.get(SessionModel, session_id)
+        assert updated is not None
+        roles = [entry["role"] for entry in updated.log_json]
+        assert roles[-3:] == ["system", "user", "assistant"]


### PR DESCRIPTION
Introduce a new API endpoint for handling chat turns in Phase1, including comprehensive error handling and logging mechanisms. Update related schemas and services to support this functionality.