### PR TITLE
Add Phase3 session creation API with goal injection and validation

### DIFF
--- a/backend/app/api/phase3_router.py
+++ b/backend/app/api/phase3_router.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session
+
+from app.core.db import get_session
+from app.schemas.phase3_schema import Phase3SessionCreateRequest, Phase3SessionCreateResponse
+from app.services import phase3_service
+
+router = APIRouter(prefix="/api/v1/phase3", tags=["phase3"])
+
+
+def _validate_user_id(user_id: Any) -> int:
+    if not isinstance(user_id, int) or isinstance(user_id, bool):
+        raise HTTPException(status_code=400, detail="user_id must be an integer")
+    return user_id
+
+
+@router.post("/session", response_model=Phase3SessionCreateResponse)
+def create_phase3_session(
+    payload: Phase3SessionCreateRequest,
+    session: Session = Depends(get_session),
+) -> Phase3SessionCreateResponse:
+    user_id = _validate_user_id(payload.user_id)
+
+    try:
+        created_session, goal_injected = phase3_service.start_phase3_session(session, user_id)
+    except phase3_service.SessionCreateError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return Phase3SessionCreateResponse(
+        session_id=created_session.id,
+        phase=created_session.phase,
+        goal_injected=goal_injected,
+        created_at=created_session.created_at,
+    )

--- a/backend/app/repositories/goals_repository.py
+++ b/backend/app/repositories/goals_repository.py
@@ -8,6 +8,16 @@ from sqlmodel import Session, select
 from app.models.goal import Goal
 
 
+def get_active_goal(session: Session, user_id: int) -> Goal | None:
+    statement = (
+        select(Goal)
+        .where(Goal.user_id == user_id)
+        .where(Goal.is_active.is_(True))
+        .limit(1)
+    )
+    return session.exec(statement).first()
+
+
 def get_max_goal_version(session: Session, user_id: int) -> int | None:
     statement = select(sa.func.max(Goal.version)).where(Goal.user_id == user_id)
     result: Any = session.exec(statement).first()

--- a/backend/app/repositories/session_repository.py
+++ b/backend/app/repositories/session_repository.py
@@ -29,6 +29,26 @@ def create_phase1_session(
     return new_session
 
 
+def create_phase3_session(
+    session: Session,
+    user_id: int,
+    session_date: date,
+    log_json: list[dict[str, Any]],
+    meta_data: dict[str, Any],
+) -> SessionModel:
+    new_session = SessionModel(
+        user_id=user_id,
+        phase=3,
+        session_date=session_date,
+        log_json=log_json,
+        meta_data=meta_data,
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(new_session)
+    session.flush()
+    return new_session
+
+
 def get_session_by_id(session: Session, session_id: UUID) -> SessionModel | None:
     return session.get(SessionModel, session_id)
 

--- a/backend/app/schemas/phase3_schema.py
+++ b/backend/app/schemas/phase3_schema.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Phase3SessionCreateRequest(BaseModel):
+    user_id: Any
+
+
+class Phase3SessionCreateResponse(BaseModel):
+    session_id: UUID
+    phase: int
+    goal_injected: bool
+    created_at: datetime

--- a/backend/app/services/phase3_service.py
+++ b/backend/app/services/phase3_service.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import Session
+
+from app.config.llm_config import LLMConfig
+from app.prompts.prompt_loader import load_prompt, resolve_prompt_version
+from app.repositories import goals_repository, session_repository
+from app.services.llm_metadata_builder import build_llm_metadata
+from app.utils.prompt_hash import generate_prompt_hash
+
+ALWAYS_ON_GOAL_PLACEHOLDER = "{{ALWAYS_ON_GOAL}}"
+DEFAULT_GOAL_TEXT = "（未設定）"
+
+
+class SessionCreateError(RuntimeError):
+    """Raised when Phase3 session creation fails."""
+
+
+def _inject_goal(system_prompt: str, goal_text: str) -> str:
+    if ALWAYS_ON_GOAL_PLACEHOLDER in system_prompt:
+        return system_prompt.replace(ALWAYS_ON_GOAL_PLACEHOLDER, goal_text)
+
+    suffix = f"\n\nAlways-on Goal:\n{goal_text}\n"
+    return f"{system_prompt.rstrip()}{suffix}"
+
+
+def start_phase3_session(session: Session, user_id: int):
+    """Create a Phase3 session with injected goal, initial log, and metadata."""
+
+    base_prompt = load_prompt("phase3")
+    prompt_version = resolve_prompt_version("phase3")
+
+    active_goal = goals_repository.get_active_goal(session, user_id)
+    goal_injected = active_goal is not None
+    goal_text = active_goal.content if active_goal is not None else DEFAULT_GOAL_TEXT
+
+    injected_prompt = _inject_goal(base_prompt, goal_text)
+    prompt_hash = generate_prompt_hash(injected_prompt)
+
+    log_json = [
+        {
+            "role": "system",
+            "content": injected_prompt,
+        }
+    ]
+
+    meta_data = build_llm_metadata(
+        LLMConfig(),
+        injected_prompt,
+        extra={
+            "prompt_version": prompt_version,
+            "prompt_hash": prompt_hash,
+        },
+    )
+
+    try:
+        created_session = session_repository.create_phase3_session(
+            session=session,
+            user_id=user_id,
+            session_date=date.today(),
+            log_json=log_json,
+            meta_data=meta_data,
+        )
+        session.commit()
+        session.refresh(created_session)
+        return created_session, goal_injected
+    except SQLAlchemyError as exc:
+        session.rollback()
+        raise SessionCreateError("Failed to create Phase3 session") from exc

--- a/backend/tests/test_phase3_session_api.py
+++ b/backend/tests/test_phase3_session_api.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from uuid import UUID
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session as SqlSession, create_engine
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+from app.api.phase3_router import router as phase3_router
+from app.core.db import get_session
+from app.models.session import Session as SessionModel
+from app.models.user import User
+from app.repositories import goals_repository
+from app.services.phase3_service import DEFAULT_GOAL_TEXT
+
+
+def _build_test_app():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    app = FastAPI()
+    app.include_router(phase3_router)
+
+    def _override_get_session():
+        with SqlSession(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    return app, engine
+
+
+def _create_user(engine) -> int:
+    with SqlSession(engine) as session:
+        user = User(name="Test User")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return int(user.id)
+
+
+def _create_active_goal(engine, user_id: int, content: str) -> None:
+    with SqlSession(engine) as session:
+        goals_repository.insert_goal(
+            session=session,
+            user_id=user_id,
+            content=content,
+            version=1,
+            is_active=True,
+        )
+        session.commit()
+
+
+def test_create_phase3_session_with_goal_injected():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+    goal_text = "毎日5分の振り返り"
+    _create_active_goal(engine, user_id, goal_text)
+    client = TestClient(app)
+
+    response = client.post("/api/v1/phase3/session", json={"user_id": user_id})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["phase"] == 3
+    assert data["goal_injected"] is True
+    assert data["session_id"]
+
+    session_id = UUID(data["session_id"])
+    with SqlSession(engine) as session:
+        created = session.get(SessionModel, session_id)
+        assert created is not None
+        assert created.log_json[0]["role"] == "system"
+        assert goal_text in created.log_json[0]["content"]
+
+
+def test_create_phase3_session_without_goal():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+    client = TestClient(app)
+
+    response = client.post("/api/v1/phase3/session", json={"user_id": user_id})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["goal_injected"] is False
+
+    session_id = UUID(data["session_id"])
+    with SqlSession(engine) as session:
+        created = session.get(SessionModel, session_id)
+        assert created is not None
+        assert DEFAULT_GOAL_TEXT in created.log_json[0]["content"]
+
+
+def test_meta_data_contains_system_prompt_hash():
+    app, engine = _build_test_app()
+    user_id_with_goal = _create_user(engine)
+    user_id_without_goal = _create_user(engine)
+    _create_active_goal(engine, user_id_with_goal, "週次レビューを続ける")
+    client = TestClient(app)
+
+    with_goal = client.post("/api/v1/phase3/session", json={"user_id": user_id_with_goal})
+    assert with_goal.status_code == 200
+    without_goal = client.post("/api/v1/phase3/session", json={"user_id": user_id_without_goal})
+    assert without_goal.status_code == 200
+
+    with_goal_id = UUID(with_goal.json()["session_id"])
+    without_goal_id = UUID(without_goal.json()["session_id"])
+
+    with SqlSession(engine) as session:
+        with_goal_session = session.get(SessionModel, with_goal_id)
+        without_goal_session = session.get(SessionModel, without_goal_id)
+        assert with_goal_session is not None
+        assert without_goal_session is not None
+
+        with_hash = with_goal_session.meta_data.get("system_prompt_hash")
+        without_hash = without_goal_session.meta_data.get("system_prompt_hash")
+
+        assert with_hash
+        assert without_hash
+        assert with_hash != without_hash


### PR DESCRIPTION
Introduce an API endpoint for creating Phase3 sessions, incorporating goal injection and validation of user IDs. This implementation includes error handling for session creation failures.