### PR TITLE
Implement Phase3 chat turn API with error handling and validation

### DIFF
--- a/backend/app/api/phase3_router.py
+++ b/backend/app/api/phase3_router.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 from typing import Any
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
 
 from app.core.db import get_session
+from app.schemas.phase3_chat_schema import (
+    Phase3ChatTurnRequest,
+    Phase3ChatTurnResponse,
+)
 from app.schemas.phase3_schema import Phase3SessionCreateRequest, Phase3SessionCreateResponse
-from app.services import phase3_service
+from app.services import phase3_chat_service, phase3_service
 
 router = APIRouter(prefix="/api/v1/phase3", tags=["phase3"])
 
@@ -35,4 +41,36 @@ def create_phase3_session(
         phase=created_session.phase,
         goal_injected=goal_injected,
         created_at=created_session.created_at,
+    )
+
+
+@router.post("/session/{session_id}/turn", response_model=Phase3ChatTurnResponse)
+async def add_phase3_chat_turn(
+    session_id: UUID,
+    payload: Phase3ChatTurnRequest,
+    session: Session = Depends(get_session),
+) -> Phase3ChatTurnResponse:
+    try:
+        assistant_message, turn_index = await phase3_chat_service.append_phase3_turn(
+            session=session,
+            session_id=session_id,
+            message=payload.message,
+        )
+    except phase3_chat_service.InvalidMessageError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except phase3_chat_service.SessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except phase3_chat_service.PhaseMismatchError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except phase3_chat_service.InvalidSessionLogError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except phase3_chat_service.LLMGenerateError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except phase3_chat_service.SessionUpdateError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return Phase3ChatTurnResponse(
+        session_id=session_id,
+        assistant_message=assistant_message,
+        turn_index=turn_index,
     )

--- a/backend/app/schemas/phase3_chat_schema.py
+++ b/backend/app/schemas/phase3_chat_schema.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class Phase3ChatTurnRequest(BaseModel):
+    message: str = Field(..., min_length=1)
+
+
+class Phase3ChatTurnResponse(BaseModel):
+    session_id: UUID
+    assistant_message: str
+    turn_index: int

--- a/backend/app/services/phase3_chat_service.py
+++ b/backend/app/services/phase3_chat_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import Session
+
+from app.config.llm_config import LLMConfig
+from app.llm.factory import get_llm_client
+from app.repositories import session_repository
+
+
+class Phase3ChatError(RuntimeError):
+    """Base error for Phase3 chat turn operations."""
+
+
+class InvalidMessageError(Phase3ChatError):
+    """Raised when the user message is invalid."""
+
+
+class SessionNotFoundError(Phase3ChatError):
+    """Raised when a session is not found."""
+
+
+class PhaseMismatchError(Phase3ChatError):
+    """Raised when a session phase does not match Phase3."""
+
+
+class InvalidSessionLogError(Phase3ChatError):
+    """Raised when session log is missing a system prompt."""
+
+
+class LLMGenerateError(Phase3ChatError):
+    """Raised when the LLM fails to generate a response."""
+
+
+class SessionUpdateError(Phase3ChatError):
+    """Raised when a session update fails."""
+
+
+def _normalize_log_json(log_json: Any) -> list[dict[str, Any]]:
+    if isinstance(log_json, list):
+        return list(log_json)
+    if isinstance(log_json, dict):
+        return [log_json]
+    return []
+
+
+def _extract_system_prompt(log_json: list[dict[str, Any]]) -> str | None:
+    if not log_json:
+        return None
+    first = log_json[0]
+    if not isinstance(first, dict):
+        return None
+    if first.get("role") != "system":
+        return None
+    content = first.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return content
+
+
+async def append_phase3_turn(
+    session: Session,
+    session_id: UUID,
+    message: str,
+) -> tuple[str, int]:
+    cleaned = message.strip() if message is not None else ""
+    if not cleaned:
+        raise InvalidMessageError("message must not be empty")
+
+    existing = session_repository.get_session_by_id(session, session_id)
+    if existing is None:
+        raise SessionNotFoundError("session not found")
+    if existing.phase != 3:
+        raise PhaseMismatchError("phase mismatch")
+
+    updated_log = _normalize_log_json(existing.log_json)
+    system_prompt = _extract_system_prompt(updated_log)
+    if system_prompt is None:
+        raise InvalidSessionLogError("invalid session log: missing system prompt")
+
+    llm_client = get_llm_client(LLMConfig())
+    try:
+        assistant_response = await llm_client.generate(system_prompt, cleaned)
+    except Exception as exc:  # noqa: BLE001
+        raise LLMGenerateError("LLM generation failed") from exc
+
+    updated_log.append({"role": "user", "content": cleaned})
+    updated_log.append({"role": "assistant", "content": assistant_response})
+
+    try:
+        updated = session_repository.update_session_log(
+            session=session,
+            session_id=existing.id,
+            log_json=updated_log,
+        )
+        if updated is None:
+            raise SessionNotFoundError("session not found")
+        session.commit()
+        session.refresh(updated)
+    except SQLAlchemyError as exc:
+        session.rollback()
+        raise SessionUpdateError("Failed to update session log") from exc
+
+    turn_index = len(updated_log) - 1
+    return assistant_response, turn_index

--- a/backend/tests/test_phase3_chat_api.py
+++ b/backend/tests/test_phase3_chat_api.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from datetime import date
+from uuid import UUID, uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session as SqlSession, create_engine
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+from app.api.phase3_router import router as phase3_router
+from app.core.db import get_session
+from app.models.session import Session as SessionModel
+from app.models.user import User
+from app.services import phase3_service
+
+
+def _build_test_app():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    app = FastAPI()
+    app.include_router(phase3_router)
+
+    def _override_get_session():
+        with SqlSession(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    return app, engine
+
+
+def _create_user(engine) -> int:
+    with SqlSession(engine) as session:
+        user = User(name="Test User")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        return int(user.id)
+
+
+def _create_phase3_session(engine, user_id: int) -> UUID:
+    with SqlSession(engine) as session:
+        created, _goal_injected = phase3_service.start_phase3_session(session, user_id)
+        return created.id
+
+
+def test_append_phase3_turn_success():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+    session_id = _create_phase3_session(engine, user_id)
+    client = TestClient(app)
+
+    with SqlSession(engine) as session:
+        before = session.get(SessionModel, session_id)
+        assert before is not None
+        before_meta = dict(before.meta_data)
+
+    response = client.post(
+        f"/api/v1/phase3/session/{session_id}/turn",
+        json={"message": "今日は1on1で部下の反応が薄くて焦った"},
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["session_id"] == str(session_id)
+    assert "[MOCK RESPONSE]" in data["assistant_message"]
+    assert isinstance(data["turn_index"], int)
+
+    with SqlSession(engine) as session:
+        updated = session.get(SessionModel, session_id)
+        assert updated is not None
+        assert isinstance(updated.log_json, list)
+        assert updated.log_json[0]["role"] == "system"
+        assert updated.log_json[-2]["role"] == "user"
+        assert updated.log_json[-1]["role"] == "assistant"
+        assert updated.meta_data == before_meta
+
+
+def test_append_phase3_turn_session_not_found():
+    app, _engine = _build_test_app()
+    client = TestClient(app)
+
+    response = client.post(
+        f"/api/v1/phase3/session/{uuid4()}/turn",
+        json={"message": "こんにちは"},
+    )
+    assert response.status_code == 404
+
+
+def test_append_phase3_turn_phase_mismatch():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+
+    with SqlSession(engine) as session:
+        wrong_phase = SessionModel(
+            id=uuid4(),
+            user_id=user_id,
+            session_date=date.today(),
+            phase=1,
+            log_json=[{"role": "system", "content": "system"}],
+            meta_data={},
+        )
+        session.add(wrong_phase)
+        session.commit()
+        session.refresh(wrong_phase)
+        session_id = wrong_phase.id
+
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/phase3/session/{session_id}/turn",
+        json={"message": "phase error"},
+    )
+    assert response.status_code == 400
+
+
+def test_append_phase3_turn_invalid_system_prompt():
+    app, engine = _build_test_app()
+    user_id = _create_user(engine)
+
+    with SqlSession(engine) as session:
+        invalid_log = SessionModel(
+            id=uuid4(),
+            user_id=user_id,
+            session_date=date.today(),
+            phase=3,
+            log_json=[{"role": "user", "content": "no system"}],
+            meta_data={},
+        )
+        session.add(invalid_log)
+        session.commit()
+        session.refresh(invalid_log)
+        session_id = invalid_log.id
+
+    client = TestClient(app)
+    response = client.post(
+        f"/api/v1/phase3/session/{session_id}/turn",
+        json={"message": "system missing"},
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
Introduce a new API endpoint for adding chat turns in Phase3, including comprehensive error handling and input validation. This enhances the robustness of the chat functionality.